### PR TITLE
308998: Add Ministerial Correspondence catalog groups

### DIFF
--- a/catalog-model/defra/arms-length-bodies/core-defra.yaml
+++ b/catalog-model/defra/arms-length-bodies/core-defra.yaml
@@ -1,0 +1,22 @@
+apiVersion: backstage.io/v1alpha1
+kind: Group
+metadata:
+  name: core-defra
+  title: DEFRA
+  description: UK government department responsible for safeguarding our natural environment, supporting our food & farming industry, and sustaining a thriving rural economy.
+  links:
+    - url: https://www.gov.uk/government/organisations/department-for-environment-food-rural-affairs/
+      title: Website
+spec:
+  type: arms-length-body
+  parent: defra
+  children: [ministerial-correspondence]
+---
+apiVersion: backstage.io/v1alpha1
+kind: Location
+metadata:
+  name: core-defra-programmes
+  description: Delivery programmes managed by Core Defra.
+spec:
+  targets:
+    - ../delivery-programmes/defra-ministerial-correspondence.yaml

--- a/catalog-model/defra/defra.yaml
+++ b/catalog-model/defra/defra.yaml
@@ -13,7 +13,7 @@ spec:
   profile:
     displayName: DEFRA
     picture: https://avatars.githubusercontent.com/u/5528822?s=200&v=4
-  children: [environment-agency, animal-plant-health-agency, rural-payments-agency, natural-england, marine-management-organisation]
+  children: [environment-agency, animal-plant-health-agency, rural-payments-agency, natural-england, marine-management-organisation, core-defra]
 ---
 apiVersion: backstage.io/v1alpha1
 kind: Location
@@ -27,3 +27,4 @@ spec:
     - ./arms-length-bodies/rural-payments-agency.yaml
     - ./arms-length-bodies/natural-england.yaml
     - ./arms-length-bodies/marine-management-organisation.yaml
+    - ./arms-length-bodies/core-defra.yaml

--- a/catalog-model/defra/delivery-programmes/defra-ministerial-correspondence.yaml
+++ b/catalog-model/defra/delivery-programmes/defra-ministerial-correspondence.yaml
@@ -1,0 +1,18 @@
+apiVersion: backstage.io/v1alpha1
+kind: Group
+metadata:
+  name: ministerial-correspondence
+  title: Ministerial Correspondence
+spec:
+  type: delivery-programme
+  parent: core-defra
+  children: [mc-ai]
+---
+apiVersion: backstage.io/v1alpha1
+kind: Location
+metadata:
+  name: mc-projects
+  description: Projects delivered by the Ministerial Correspondence programme.
+spec: 
+  targets:
+    - ../projects/mc-ai.yaml

--- a/catalog-model/defra/projects/mc-ai.yaml
+++ b/catalog-model/defra/projects/mc-ai.yaml
@@ -1,0 +1,12 @@
+apiVersion: backstage.io/v1alpha1
+kind: Group
+metadata:
+  name: mc-ai
+  description: Ministerial Correspondence AI
+spec:
+  type: team
+  profile:
+    displayName: Ministerial Correspondence AI
+    picture: https://avatars.githubusercontent.com/u/5528822?s=200&v=4
+  parent: ministerial-correspondence
+  children: []


### PR DESCRIPTION
# **What this PR does / why we need it**:
Adds group data to the catalog to support the Ministerial Correspondence project:
ALB: Core DEFRA
Programme: Ministerial Correspondence
Project: Ministerial Correspondence AI

[AB#308998](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/308998)

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests


# **How does this PR make you feel**:
![gif]([https://giphy.com/)