### PR TITLE
334408: Fix for ingress server name in helm values

### DIFF
--- a/templates/adp-frontend-template-node/skeleton/helm/${{ values.project_name }}/values.yaml
+++ b/templates/adp-frontend-template-node/skeleton/helm/${{ values.project_name }}/values.yaml
@@ -39,4 +39,4 @@ readinessProbe:
 ingress:
   class: nginx
   endpoint: ${{ values.project_name }}
-  server: ${{ values.project_name }}.{ENVIRONMENT}.adp.defra.gov.uk
+  server: environment.adp.defra.gov.uk


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this PR closes an issue, add '<[AB#213700](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/213700)>' somewhere in the PR summary. As a minimum, please *always* link to the relevant work items e.g. [AB#213700](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/213700) (work item number in Azure DevOps). Follow the format below carefully, guidance found here: https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops. Note: The Title pattern should be `{work item number}: {title}` -->

# **What this PR does / why we need it**:
Fix for ingress server name in helm values. {ENVIRONMENT} present earlier was causing issues in helm chart deployment on cluster.
[AB#334408](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/334408)

# **Special notes for your reviewer**
*Any specific actions or notes on review?*

# Testing
*Any relevant testing information and pipeline runs.*

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests

# **How does this PR make you feel**:
![gif]([https://giphy.com/)