### PR TITLE
341023: Remove ALB targets from catalog

### DIFF
--- a/catalog-model/defra/defra.yaml
+++ b/catalog-model/defra/defra.yaml
@@ -13,18 +13,20 @@ spec:
   profile:
     displayName: DEFRA
     picture: https://avatars.githubusercontent.com/u/5528822?s=200&v=4
-  children: [environment-agency, animal-plant-health-agency, rural-payments-agency, natural-england, marine-management-organisation, core-defra]
+  children: []
 ---
 apiVersion: backstage.io/v1alpha1
 kind: Location
 metadata:
-  name: defra-arms-length-bodies
-  description: Arms Length Bodies under the DEFRA organisation.
+  name: defra-delivery-programmes
+  description: All delivery programmes within the Defra organization.
 spec:
   targets:
-    - ./arms-length-bodies/environment-agency.yaml
-    - ./arms-length-bodies/animal-plant-health-agency.yaml
-    - ./arms-length-bodies/rural-payments-agency.yaml
-    - ./arms-length-bodies/natural-england.yaml
-    - ./arms-length-bodies/marine-management-organisation.yaml
-    - ./arms-length-bodies/core-defra.yaml
+    - ./delivery-programmes/apha-europe-trade.yaml
+    - ./delivery-programmes/coreai.yaml
+    - ./delivery-programmes/ea-extended-producer-responsibility.yaml
+    - ./delivery-programmes/mmo-fisheries.yaml
+    - ./delivery-programmes/ne-biodiversity-net-gains.yaml
+    - ./delivery-programmes/rpa-farming-countryside-programme.yaml
+    - ./delivery-programmes/rpa-legacy-applications-programme.yaml
+


### PR DESCRIPTION
# **What this PR does / why we need it**:
We need to migrate Arms Length Body entities from this repo to the custom ADP plugin database. This PR removes the targets which point to these entities, which removes them from the software catalog. After the entities have been fully migrated they can be removed from this repo.

Targets now point to delivery programmes to ensure these are still pulled into the catalog pending their migration.

[AB#341023](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/341023)

# **Special notes for your reviewer**
Migration plan:

1. Merge this PR first. This will remove the existing ALB entities from Backstage
2. Merge https://github.com/DEFRA/adp-portal/pull/53. This will enable the entity provider which will pull ALBs from the adp plugin database into the software catalog.
3. Update this repo to remove the ALB entities
4. Rinse and repeat steps 1-3 for delivery programmes and delivery projects

# Testing
*Any relevant testing information and pipeline runs.*

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests

# **How does this PR make you feel**:
![gif]([https://giphy.com/)