### PR TITLE
345221: Templates add service to the flux config

### DIFF
--- a/templates/adp-backend-template-node/template.yaml
+++ b/templates/adp-backend-template-node/template.yaml
@@ -316,7 +316,7 @@ spec:
             - TST2
             - PRE1
             - PRD1
-          configVariables:
+          configVariables: {}
 
     - id: configureAdoProject
       name: Configure Azure DevOps Project

--- a/templates/adp-backend-template-node/template.yaml
+++ b/templates/adp-backend-template-node/template.yaml
@@ -303,7 +303,7 @@ spec:
       action: http:backstage:request
       input:
         method: POST
-        path: /proxy/adp-portal-api/TeamFluxConfig/${{ parameters.owner | parseEntityRef | pick('name') }}/services
+        path: /proxy/adp-portal-api/FluxTeamConfig/${{ parameters.owner | parseEntityRef | pick('name') }}/services
         headers:
           content-type: "application/json"
         body:

--- a/templates/adp-backend-template-node/template.yaml
+++ b/templates/adp-backend-template-node/template.yaml
@@ -85,7 +85,7 @@ spec:
             - None
 
         app_infra_postgres_db_check:
-          title: Do you need an Azure Postgres FlexibleServer Database?
+          title: Do you need an Azure PostgreSQL Database?
           type: string
           description: Select if a database is required. (These resources are just to get started. More resources can be added later to code by developers.)
           default: no

--- a/templates/adp-backend-template-node/template.yaml
+++ b/templates/adp-backend-template-node/template.yaml
@@ -303,7 +303,7 @@ spec:
       action: http:backstage:request
       input:
         method: POST
-        path: /proxy/adp-portal-api/TeamFluxConfig/${{ parameters.owner }}/services
+        path: /proxy/adp-portal-api/TeamFluxConfig/${{ parameters.owner | parseEntityRef | pick('name') }}/services
         headers:
           content-type: "application/json"
         body:

--- a/templates/adp-backend-template-node/template.yaml
+++ b/templates/adp-backend-template-node/template.yaml
@@ -83,9 +83,9 @@ spec:
             - Queue
             - Topic
             - None
-        
+
         app_infra_postgres_db_check:
-          title: Do you need an Azure Postgres FlexibleServer Database? 
+          title: Do you need an Azure Postgres FlexibleServer Database?
           type: string
           description: Select if a database is required. (These resources are just to get started. More resources can be added later to code by developers.)
           default: no
@@ -121,8 +121,8 @@ spec:
                       - Publisher
                       - Subscriber
                 required:
-                - app_infra_service_bus_resource_name
-                - app_infra_service_bus_resource_type
+                  - app_infra_service_bus_resource_name
+                  - app_infra_service_bus_resource_type
             - if:
                 properties:
                   app_infra_service_bus_check:
@@ -145,8 +145,8 @@ spec:
                       - Publisher
                       - Subscriber
                 required:
-                - app_infra_service_bus_resource_name
-                - app_infra_service_bus_resource_type
+                  - app_infra_service_bus_resource_name
+                  - app_infra_service_bus_resource_type
 
         app_infra_postgres_db_check:
           allOf:
@@ -161,7 +161,7 @@ spec:
                     type: string
                     description: Provide the database name.
                 required:
-                - app_infra_postgres_db_resource_name
+                  - app_infra_postgres_db_resource_name
 
     - title: Git Repository
       description: |
@@ -265,7 +265,7 @@ spec:
       name: Publish
       action: publish:github
       input:
-        allowedHosts: ['github.com']
+        allowedHosts: ["github.com"]
         description: ${{ parameters.description }}
         repoUrl: ${{ parameters.repo_url }}
         requireCodeOwnerReviews: true
@@ -298,6 +298,26 @@ spec:
         owner: ${{ parameters.repo_url | parseRepoUrl | pick('owner') }}
         permission: push
 
+    - id: registerFluxService
+      name: Register Service in Flux config
+      action: http:backstage:request
+      input:
+        method: POST
+        path: /proxy/adp-portal-api/TeamFluxConfig/${{ parameters.owner }}/services
+        headers:
+          content-type: "application/json"
+        body:
+          name: ${{ parameters.component_id }}
+          isFrontEnd: false
+          environments:
+            - SND3
+            - DEV1
+            - TST1
+            - TST2
+            - PRE1
+            - PRD1
+          configVariables:
+
     - id: configureAdoProject
       name: Configure Azure DevOps Project
       action: http:backstage:request
@@ -305,75 +325,75 @@ spec:
         method: PATCH
         path: /proxy/adp-portal-api/AdoProject/${{ parameters.ado_project }}/onboard
         headers:
-          content-type: 'application/json'
+          content-type: "application/json"
         body:
           environments:
-          - name: SND3
-            description: SND environment
-          - name: DEV1
-            description: DEV1 environment
-          - name: TST1
-            description: TST1 environment
-          - name: TST2
-            description: TST2 environment
-          - name: PRE1
-            description: PRE1 environment
-          - name: PRD1
-            description: PRD1 environment
+            - name: SND3
+              description: SND environment
+            - name: DEV1
+              description: DEV1 environment
+            - name: TST1
+              description: TST1 environment
+            - name: TST2
+              description: TST2 environment
+            - name: PRE1
+              description: PRE1 environment
+            - name: PRD1
+              description: PRD1 environment
           serviceConnections:
-          - AZD-ADP-SND1
-          - AZD-ADP-SND2
-          - AZD-ADP-SND3
-          - AZD-ADP-SSV3
-          - AZR-ADP-DEV1
-          - AZR-ADP-TST1
-          - AZR-ADP-PRE1
-          - AZD-ADP-SNYK
-          - Defra-ADP-Github
-          - DEFRA-ADP-SonarCloud
+            - AZD-ADP-SND1
+            - AZD-ADP-SND2
+            - AZD-ADP-SND3
+            - AZD-ADP-SSV3
+            - AZR-ADP-DEV1
+            - AZR-ADP-TST1
+            - AZR-ADP-PRE1
+            - AZD-ADP-SNYK
+            - Defra-ADP-Github
+            - DEFRA-ADP-SonarCloud
           agentPools:
-          - DEFRA-ADP-SND1-ubuntu2204
-          - DEFRA-ADP-SND3-ubuntu2204
-          - DEFRA-ADP-DEV1-ubuntu2204
-          - DEFRA-ADP-TST1-ubuntu2204
-          - DEFRA-ADP-PRE1-ubuntu2204
+            - DEFRA-ADP-SND1-ubuntu2204
+            - DEFRA-ADP-SND3-ubuntu2204
+            - DEFRA-ADP-DEV1-ubuntu2204
+            - DEFRA-ADP-TST1-ubuntu2204
+            - DEFRA-ADP-PRE1-ubuntu2204
           variableGroups:
-          - name: ${{ parameters.component_id }}-snd3
-            description: Variables for the ${{ parameters.component_id }} service
-            variables:
-            - name: ${{ parameters.component_id }}-APPINSIGHTS-CONNECTIONSTRING
-              value: TEST
-              isSecret: true
-          - name: ${{ parameters.component_id }}-dev1
-            description: Variables for the ${{ parameters.component_id }} service
-            variables:
-            - name: ${{ parameters.component_id }}-APPINSIGHTS-CONNECTIONSTRING
-              value: TEST
-              isSecret: true
-          - name: ${{ parameters.component_id }}-tst1
-            description: Variables for the ${{ parameters.component_id }} service
-            variables:
-            - name: ${{ parameters.component_id }}-APPINSIGHTS-CONNECTIONSTRING
-              value: TEST
-              isSecret: true
-          - name: ${{ parameters.component_id }}-tst2
-            description: Variables for the ${{ parameters.component_id }} service
-            variables:
-            - name: ${{ parameters.component_id }}-APPINSIGHTS-CONNECTIONSTRING
-              value: TEST
-              isSecret: true
-          - name: ${{ parameters.component_id }}-pre1
-            description: Variables for the ${{ parameters.component_id }} service
-            variables:
-            - name: ${{ parameters.component_id }}-APPINSIGHTS-CONNECTIONSTRING
-              value: TEST
-              isSecret: true
-          - name: ${{ parameters.component_id }}-prd1
-            description: Variables for the ${{ parameters.component_id }} service
-            variables:
-            - name: ${{ parameters.component_id }}-APPINSIGHTS-CONNECTIONSTRING
-              value: TEST
-              isSecret: true
+            - name: ${{ parameters.component_id }}-snd3
+              description: Variables for the ${{ parameters.component_id }} service
+              variables:
+                - name: ${{ parameters.component_id }}-APPINSIGHTS-CONNECTIONSTRING
+                  value: TEST
+                  isSecret: true
+            - name: ${{ parameters.component_id }}-dev1
+              description: Variables for the ${{ parameters.component_id }} service
+              variables:
+                - name: ${{ parameters.component_id }}-APPINSIGHTS-CONNECTIONSTRING
+                  value: TEST
+                  isSecret: true
+            - name: ${{ parameters.component_id }}-tst1
+              description: Variables for the ${{ parameters.component_id }} service
+              variables:
+                - name: ${{ parameters.component_id }}-APPINSIGHTS-CONNECTIONSTRING
+                  value: TEST
+                  isSecret: true
+            - name: ${{ parameters.component_id }}-tst2
+              description: Variables for the ${{ parameters.component_id }} service
+              variables:
+                - name: ${{ parameters.component_id }}-APPINSIGHTS-CONNECTIONSTRING
+                  value: TEST
+                  isSecret: true
+            - name: ${{ parameters.component_id }}-pre1
+              description: Variables for the ${{ parameters.component_id }} service
+              variables:
+                - name: ${{ parameters.component_id }}-APPINSIGHTS-CONNECTIONSTRING
+                  value: TEST
+                  isSecret: true
+            - name: ${{ parameters.component_id }}-prd1
+              description: Variables for the ${{ parameters.component_id }} service
+              variables:
+                - name: ${{ parameters.component_id }}-APPINSIGHTS-CONNECTIONSTRING
+                  value: TEST
+                  isSecret: true
 
     - id: logConfigureAdoProjectReponse
       name: Log Azure DevOps Project Configuration
@@ -429,7 +449,7 @@ spec:
       action: catalog:register
       input:
         repoContentsUrl: ${{ steps.publish.output.repoContentsUrl }}
-        catalogInfoPath: '/catalog-info.yaml'
+        catalogInfoPath: "/catalog-info.yaml"
 
   output:
     links:

--- a/templates/adp-empty-project-template/template.yaml
+++ b/templates/adp-empty-project-template/template.yaml
@@ -193,7 +193,7 @@ spec:
       action: http:backstage:request
       input:
         method: POST
-        path: /proxy/adp-portal-api/TeamFluxConfig/${{ parameters.owner | parseEntityRef | pick('name') }}/services
+        path: /proxy/adp-portal-api/FluxTeamConfig/${{ parameters.owner | parseEntityRef | pick('name') }}/services
         headers:
           content-type: "application/json"
         body:

--- a/templates/adp-empty-project-template/template.yaml
+++ b/templates/adp-empty-project-template/template.yaml
@@ -33,7 +33,7 @@ spec:
           title: Description
           type: string
           description: Describe what this component does. This description will be used in the component's README and package.json.
-       
+
         component_type:
           title: Component Type
           type: string
@@ -51,7 +51,7 @@ spec:
             - Library
             - Website
             - Other
-       
+
         owner:
           title: Owner
           type: string
@@ -61,7 +61,7 @@ spec:
             catalogFilter:
               - kind: Group
                 spec.type: team
-        
+
         system:
           title: System
           type: string
@@ -85,7 +85,6 @@ spec:
             - Discovery
             - Alpha
             - Beta
-
 
     - title: Git Repository
       description: |
@@ -189,6 +188,26 @@ spec:
         owner: ${{ parameters.repo_url | parseRepoUrl | pick('owner') }}
         permission: push
 
+    - id: registerFluxService
+      name: Register Service in Flux config
+      action: http:backstage:request
+      input:
+        method: POST
+        path: /proxy/adp-portal-api/TeamFluxConfig/${{ parameters.owner }}/services
+        headers:
+          content-type: "application/json"
+        body:
+          name: ${{ parameters.component_id }}
+          isFrontEnd: ${{ parameters.component_type | isOneOf("frontend", "website") }}
+          environments:
+            - SND3
+            - DEV1
+            - TST1
+            - TST2
+            - PRE1
+            - PRD1
+          configVariables:
+
     - id: register
       name: Register
       action: catalog:register
@@ -204,4 +223,3 @@ spec:
       - title: Open in catalog
         icon: catalog
         entityRef: ${{ steps.register.output.entityRef }}
-

--- a/templates/adp-empty-project-template/template.yaml
+++ b/templates/adp-empty-project-template/template.yaml
@@ -206,7 +206,7 @@ spec:
             - TST2
             - PRE1
             - PRD1
-          configVariables:
+          configVariables: {}
 
     - id: register
       name: Register

--- a/templates/adp-empty-project-template/template.yaml
+++ b/templates/adp-empty-project-template/template.yaml
@@ -193,7 +193,7 @@ spec:
       action: http:backstage:request
       input:
         method: POST
-        path: /proxy/adp-portal-api/TeamFluxConfig/${{ parameters.owner }}/services
+        path: /proxy/adp-portal-api/TeamFluxConfig/${{ parameters.owner | parseEntityRef | pick('name') }}/services
         headers:
           content-type: "application/json"
         body:

--- a/templates/adp-frontend-template-node/template.yaml
+++ b/templates/adp-frontend-template-node/template.yaml
@@ -300,7 +300,7 @@ spec:
             - TST2
             - PRE1
             - PRD1
-          configVariables:
+          configVariables: {}
 
     - id: configureAdoProject
       name: Configure Azure DevOps Project

--- a/templates/adp-frontend-template-node/template.yaml
+++ b/templates/adp-frontend-template-node/template.yaml
@@ -287,7 +287,7 @@ spec:
       action: http:backstage:request
       input:
         method: POST
-        path: /proxy/adp-portal-api/TeamFluxConfig/${{ parameters.owner }}/services
+        path: /proxy/adp-portal-api/TeamFluxConfig/${{ parameters.owner | parseEntityRef | pick('name') }}/services
         headers:
           content-type: "application/json"
         body:

--- a/templates/adp-frontend-template-node/template.yaml
+++ b/templates/adp-frontend-template-node/template.yaml
@@ -287,7 +287,7 @@ spec:
       action: http:backstage:request
       input:
         method: POST
-        path: /proxy/adp-portal-api/TeamFluxConfig/${{ parameters.owner | parseEntityRef | pick('name') }}/services
+        path: /proxy/adp-portal-api/FluxTeamConfig/${{ parameters.owner | parseEntityRef | pick('name') }}/services
         headers:
           content-type: "application/json"
         body:

--- a/templates/adp-frontend-template-node/template.yaml
+++ b/templates/adp-frontend-template-node/template.yaml
@@ -121,8 +121,8 @@ spec:
                       - Publisher
                       - Subscriber
                 required:
-                - app_infra_service_bus_resource_name
-                - app_infra_service_bus_resource_type
+                  - app_infra_service_bus_resource_name
+                  - app_infra_service_bus_resource_type
             - if:
                 properties:
                   app_infra_service_bus_check:
@@ -145,8 +145,8 @@ spec:
                       - Publisher
                       - Subscriber
                 required:
-                - app_infra_service_bus_resource_name
-                - app_infra_service_bus_resource_type
+                  - app_infra_service_bus_resource_name
+                  - app_infra_service_bus_resource_type
 
     - title: Git Repository
       description: |
@@ -282,6 +282,26 @@ spec:
         owner: ${{ parameters.repo_url | parseRepoUrl | pick('owner') }}
         permission: push
 
+    - id: registerFluxService
+      name: Register Service in Flux config
+      action: http:backstage:request
+      input:
+        method: POST
+        path: /proxy/adp-portal-api/TeamFluxConfig/${{ parameters.owner }}/services
+        headers:
+          content-type: "application/json"
+        body:
+          name: ${{ parameters.component_id }}
+          isFrontEnd: true
+          environments:
+            - SND3
+            - DEV1
+            - TST1
+            - TST2
+            - PRE1
+            - PRD1
+          configVariables:
+
     - id: configureAdoProject
       name: Configure Azure DevOps Project
       action: http:backstage:request
@@ -289,75 +309,75 @@ spec:
         method: PATCH
         path: /proxy/adp-portal-api/AdoProject/${{ parameters.ado_project }}/onboard
         headers:
-          content-type: 'application/json'
+          content-type: "application/json"
         body:
           environments:
-          - name: SND3
-            description: SND environment
-          - name: DEV1
-            description: DEV1 environment
-          - name: TST1
-            description: TST1 environment
-          - name: TST2
-            description: TST2 environment
-          - name: PRE1
-            description: PRE1 environment
-          - name: PRD1
-            description: PRD1 environment
+            - name: SND3
+              description: SND environment
+            - name: DEV1
+              description: DEV1 environment
+            - name: TST1
+              description: TST1 environment
+            - name: TST2
+              description: TST2 environment
+            - name: PRE1
+              description: PRE1 environment
+            - name: PRD1
+              description: PRD1 environment
           serviceConnections:
-          - AZD-ADP-SND1
-          - AZD-ADP-SND2
-          - AZD-ADP-SND3
-          - AZD-ADP-SSV3
-          - AZR-ADP-DEV1
-          - AZR-ADP-TST1
-          - AZR-ADP-PRE1
-          - AZD-ADP-SNYK
-          - Defra-ADP-Github
-          - DEFRA-ADP-SonarCloud
+            - AZD-ADP-SND1
+            - AZD-ADP-SND2
+            - AZD-ADP-SND3
+            - AZD-ADP-SSV3
+            - AZR-ADP-DEV1
+            - AZR-ADP-TST1
+            - AZR-ADP-PRE1
+            - AZD-ADP-SNYK
+            - Defra-ADP-Github
+            - DEFRA-ADP-SonarCloud
           agentPools:
-          - DEFRA-ADP-SND1-ubuntu2204
-          - DEFRA-ADP-SND3-ubuntu2204
-          - DEFRA-ADP-DEV1-ubuntu2204
-          - DEFRA-ADP-TST1-ubuntu2204
-          - DEFRA-ADP-PRE1-ubuntu2204
+            - DEFRA-ADP-SND1-ubuntu2204
+            - DEFRA-ADP-SND3-ubuntu2204
+            - DEFRA-ADP-DEV1-ubuntu2204
+            - DEFRA-ADP-TST1-ubuntu2204
+            - DEFRA-ADP-PRE1-ubuntu2204
           variableGroups:
-          - name: ${{ parameters.component_id }}-snd3
-            description: Variables for the ${{ parameters.component_id }} service
-            variables:
-            - name: ${{ parameters.component_id }}-APPINSIGHTS-CONNECTIONSTRING
-              value: TEST
-              isSecret: true
-          - name: ${{ parameters.component_id }}-dev1
-            description: Variables for the ${{ parameters.component_id }} service
-            variables:
-            - name: ${{ parameters.component_id }}-APPINSIGHTS-CONNECTIONSTRING
-              value: TEST
-              isSecret: true
-          - name: ${{ parameters.component_id }}-tst1
-            description: Variables for the ${{ parameters.component_id }} service
-            variables:
-            - name: ${{ parameters.component_id }}-APPINSIGHTS-CONNECTIONSTRING
-              value: TEST
-              isSecret: true
-          - name: ${{ parameters.component_id }}-tst2
-            description: Variables for the ${{ parameters.component_id }} service
-            variables:
-            - name: ${{ parameters.component_id }}-APPINSIGHTS-CONNECTIONSTRING
-              value: TEST
-              isSecret: true
-          - name: ${{ parameters.component_id }}-pre1
-            description: Variables for the ${{ parameters.component_id }} service
-            variables:
-            - name: ${{ parameters.component_id }}-APPINSIGHTS-CONNECTIONSTRING
-              value: TEST
-              isSecret: true
-          - name: ${{ parameters.component_id }}-prd1
-            description: Variables for the ${{ parameters.component_id }} service
-            variables:
-            - name: ${{ parameters.component_id }}-APPINSIGHTS-CONNECTIONSTRING
-              value: TEST
-              isSecret: true
+            - name: ${{ parameters.component_id }}-snd3
+              description: Variables for the ${{ parameters.component_id }} service
+              variables:
+                - name: ${{ parameters.component_id }}-APPINSIGHTS-CONNECTIONSTRING
+                  value: TEST
+                  isSecret: true
+            - name: ${{ parameters.component_id }}-dev1
+              description: Variables for the ${{ parameters.component_id }} service
+              variables:
+                - name: ${{ parameters.component_id }}-APPINSIGHTS-CONNECTIONSTRING
+                  value: TEST
+                  isSecret: true
+            - name: ${{ parameters.component_id }}-tst1
+              description: Variables for the ${{ parameters.component_id }} service
+              variables:
+                - name: ${{ parameters.component_id }}-APPINSIGHTS-CONNECTIONSTRING
+                  value: TEST
+                  isSecret: true
+            - name: ${{ parameters.component_id }}-tst2
+              description: Variables for the ${{ parameters.component_id }} service
+              variables:
+                - name: ${{ parameters.component_id }}-APPINSIGHTS-CONNECTIONSTRING
+                  value: TEST
+                  isSecret: true
+            - name: ${{ parameters.component_id }}-pre1
+              description: Variables for the ${{ parameters.component_id }} service
+              variables:
+                - name: ${{ parameters.component_id }}-APPINSIGHTS-CONNECTIONSTRING
+                  value: TEST
+                  isSecret: true
+            - name: ${{ parameters.component_id }}-prd1
+              description: Variables for the ${{ parameters.component_id }} service
+              variables:
+                - name: ${{ parameters.component_id }}-APPINSIGHTS-CONNECTIONSTRING
+                  value: TEST
+                  isSecret: true
 
     - id: logConfigureAdoProjectReponse
       name: Log Azure DevOps Project Configuration


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this PR closes an issue, add '<[AB#213700](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/213700)>' somewhere in the PR summary. As a minimum, please *always* link to the relevant work items e.g. [AB#213700](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/213700) (work item number in Azure DevOps). Follow the format below carefully, guidance found here: https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops. Note: The Title pattern should be `{work item number}: {title}` -->

# **What this PR does / why we need it**:
Adds steps into the templates to add the service to the flux config
[AB#345221](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/345221)

# **Special notes for your reviewer**

# Testing

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests

# **How does this PR make you feel**:
![gif]([https://giphy.com/)