### PR TITLE
276865: Update owner picker team type

### DIFF
--- a/templates/adp-backend-template-node/template.yaml
+++ b/templates/adp-backend-template-node/template.yaml
@@ -68,7 +68,7 @@ spec:
           ui:options:
             catalogFilter:
               - kind: Group
-                spec.type: team
+                spec.type: delivery-project
 
         app_infra_service_bus_check:
           title: Do you need an Azure Service Bus Queue or Topic?

--- a/templates/adp-empty-project-template/template.yaml
+++ b/templates/adp-empty-project-template/template.yaml
@@ -60,7 +60,7 @@ spec:
           ui:options:
             catalogFilter:
               - kind: Group
-                spec.type: team
+                spec.type: delivery-project
 
         system:
           title: System

--- a/templates/adp-frontend-template-node/template.yaml
+++ b/templates/adp-frontend-template-node/template.yaml
@@ -80,7 +80,7 @@ spec:
           ui:options:
             catalogFilter:
               - kind: Group
-                spec.type: team
+                spec.type: delivery-project
 
         app_infra_service_bus_check:
           title: Do you need an Azure Service Bus Queue or Topic?

--- a/templates/adp-helm-only-template/template.yaml
+++ b/templates/adp-helm-only-template/template.yaml
@@ -64,7 +64,7 @@ spec:
           ui:options:
             catalogFilter:
               - kind: Group
-                spec.type: team
+                spec.type: delivery-project
 
         endpoint:
           title: Endpoint


### PR DESCRIPTION
# **What this PR does / why we need it**:
Updates the owner picker to look for groups of type delivery-project following implementation of the entity provider. [AB#276865](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/276865)

# **Special notes for your reviewer**
*Any specific actions or notes on review?*

# Testing
*Any relevant testing information and pipeline runs.*

# Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests

# **How does this PR make you feel**:
![gif]([https://giphy.com/)