### PR TITLE
275171: Updated to use the same AppInsights config names as nodejs 

### DIFF
--- a/templates/adp-backend-template-dotnet/skeleton/README.md
+++ b/templates/adp-backend-template-dotnet/skeleton/README.md
@@ -1,11 +1,14 @@
 # ${{ values.service_name }}
+
 ${{ values.service_name }} Dotnet service.
 
 ## Prerequisites
+
 - Docker
 - Docker Compose
 
 Optional:
+
 - Kubernetes
 - Helm
 - Access to an instance of an [Azure Service Bus](https://docs.microsoft.com/en-us/azure/service-bus-messaging/)
@@ -14,10 +17,10 @@ Optional:
 
 The following environment variables are required by the application container. Values for development are set in the Docker Compose configuration. Default values for production-like deployments are set in the Helm chart and may be overridden by build and release pipelines.
 
-| Name                                    | Description                        | Required | Default   | Valid | Notes                                                                 |
-| ----                                    | -----------                        | -------- | -------   | ----- | -----                                                                 |
-| ApplicationInsights__ConnectionString   | App Insights key                   | no       |           |       | will log to Azure Application Insights if set                         |
-| ApplicationInsights__CloudRole          | Role used for filtering metrics    | no       |           |       | Set to `${{ values.service_name }}-local` in docker compose files    |
+| Name                         | Description                     | Required | Default | Valid | Notes                                                                                                                             |
+| ---------------------------- | ------------------------------- | -------- | ------- | ----- | --------------------------------------------------------------------------------------------------------------------------------- |
+| APPINSIGHTS_CONNECTIONSTRING | App Insights connection string  | no       |         |       | will log to Azure Application Insights if set in local development. During deployment to AKS it is automatically set by platform. |
+| APPINSIGHTS_CLOUDROLE        | Role used for filtering metrics | no       |         |       | Set to `adp-backend-template-dotnet-local` in docker compose files                                                                |
 
 ## Test structure
 
@@ -38,20 +41,25 @@ scripts/test -w
 ```
 
 ### docker-compose.test.yaml
+
 This file runs all tests and exits the container. If any tests fails the error will be output. Use the docker-compose `-p` flag to avoid conflicting with a running app instance:
 
 `docker-compose -p ${{ values.service_name }}-test -f docker-compose.yaml -f docker-compose.test.yaml up`
 
 ### docker-compose.test.watch.yaml
-This file is intended to be an override file for `docker-compose.test.yaml`.  The container will not exit following test run, instead it will watch for code changes in the application or tests and rerun on occurrence.
+
+This file is intended to be an override file for `docker-compose.test.yaml`. The container will not exit following test run, instead it will watch for code changes in the application or tests and rerun on occurrence.
 
 `docker-compose -p ${{ values.service_name }}-test -f docker-compose.yaml -f docker-compose.test.watch.yaml up`
 
 ## Running the application
+
 The application is designed to run in containerised environments, using Docker Compose in development and Kubernetes in production.
+
 - A Helm chart is provided for production deployments to Kubernetes.
 
 ### Build container image
+
 Container images are built using Docker Compose, with the same images used to run the service with either Docker Compose or Kubernetes.
 
 By default, the start script will build (or rebuild) images so there will rarely be a need to build images manually. However, this can be achieved through the Docker Compose [build](https://docs.docker.com/compose/reference/build/) command:
@@ -62,6 +70,7 @@ docker-compose build
 ```
 
 ### Start and stop the service
+
 Use Docker Compose to run service locally.
 
 ```
@@ -82,9 +91,10 @@ Additional Docker Compose files are provided for scenarios such as linking to ot
 
 ### Deploy to Kubernetes
 
-For production deployments, a helm chart is included in the `.\helm` folder. 
+For production deployments, a helm chart is included in the `.\helm` folder.
 
 #### Probes
+
 The service has both an Http readiness probe and an Http liveness probe configured to receive at the below end points.
 
 Readiness: `/healthy`
@@ -95,6 +105,7 @@ Liveness: `/healthz`
 This service uses the [ADP Common Pipelines](https://github.com/DEFRA/adp-pipeline-common) for Builds and Deployments.
 
 ### AppConfig - KeyVault References
+
 If the application uses `keyvault references` in `appConfig.env.yaml`, please make sure the variable to be added to keyvault is created in ADO Library variable groups and the reference for the variable groups and variables are provided in `build.yaml` like below.
 
 ```
@@ -107,6 +118,7 @@ variables:
 ```
 
 ## Licence
+
 THIS INFORMATION IS LICENSED UNDER THE CONDITIONS OF THE OPEN GOVERNMENT LICENCE found at:
 
 <http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3>
@@ -116,6 +128,7 @@ The following attribution statement MUST be cited in your products and applicati
 > Contains public sector information licensed under the Open Government license v3
 
 ### About the licence
+
 The Open Government Licence (OGL) was developed by the Controller of Her Majesty's Stationery Office (HMSO) to enable information providers in the public sector to license the use and re-use of their information under a common open licence.
 
 It is designed to encourage use and re-use of information freely and flexibly, with only a few conditions.

--- a/templates/adp-backend-template-dotnet/skeleton/README.md
+++ b/templates/adp-backend-template-dotnet/skeleton/README.md
@@ -20,7 +20,7 @@ The following environment variables are required by the application container. V
 | Name                         | Description                     | Required | Default | Valid | Notes                                                                                                                             |
 | ---------------------------- | ------------------------------- | -------- | ------- | ----- | --------------------------------------------------------------------------------------------------------------------------------- |
 | APPINSIGHTS_CONNECTIONSTRING | App Insights connection string  | no       |         |       | will log to Azure Application Insights if set in local development. During deployment to AKS it is automatically set by platform. |
-| APPINSIGHTS_CLOUDROLE        | Role used for filtering metrics | no       |         |       | Set to `adp-backend-template-dotnet-local` in docker compose files                                                                |
+| APPINSIGHTS_CLOUDROLE        | Role used for filtering metrics | no       |         |       | Set to `${{ values.service_name }}-local` in docker compose files                                                                |
 
 ## Test structure
 

--- a/templates/adp-backend-template-dotnet/skeleton/docker-compose.yaml
+++ b/templates/adp-backend-template-dotnet/skeleton/docker-compose.yaml
@@ -6,5 +6,5 @@ services:
     image: ${{ values.service_name }}
     container_name: ${{ values.service_name }}
     environment:
-      AppInsights__ConnectionString: ${APPINSIGHTS_CONNECTIONSTRING}
-      AppInsights__CloudRole: ${{ values.service_name }}-local
+      APPINSIGHTS_CONNECTIONSTRING: ${APPINSIGHTS_CONNECTIONSTRING}
+      APPINSIGHTS_CLOUDROLE: ${{ values.service_name }}-local

--- a/templates/adp-backend-template-dotnet/skeleton/src/${{ values.dotnet_solution_name }}.Api/Extensions/BuilderExtensions.cs
+++ b/templates/adp-backend-template-dotnet/skeleton/src/${{ values.dotnet_solution_name }}.Api/Extensions/BuilderExtensions.cs
@@ -19,7 +19,10 @@ public static class BuilderExtensions
             builder.Services.AddOpenTelemetry().UseAzureMonitor(options =>
             {
                 options.ConnectionString = appInsightsConfig.ConnectionString;
-                options.Credential = new DefaultAzureCredential();
+                if (builder.Environment.IsProduction())
+                {
+                    options.Credential = new DefaultAzureCredential();
+                }
             });
             if (!string.IsNullOrEmpty(appInsightsConfig.CloudRole))
             {

--- a/templates/adp-backend-template-dotnet/skeleton/src/${{ values.dotnet_solution_name }}.Api/Program.cs
+++ b/templates/adp-backend-template-dotnet/skeleton/src/${{ values.dotnet_solution_name }}.Api/Program.cs
@@ -62,16 +62,13 @@ public static class Program
                .AddCheck<LivenessCheck>("live")
                .AddCheck<ReadinessCheck>("ready");
 
-        var appInsightsConfig = builder.Configuration.GetSection("AppInsights").Get<AppInsightsConfig>();
+        var appInsightsConfig = new AppInsightsConfig
+        {
+            CloudRole = builder.Configuration.GetValue<string>("APPINSIGHTS_CLOUDROLE") ?? "",
+            ConnectionString = builder.Configuration.GetValue<string>("APPINSIGHTS_CONNECTIONSTRING") ?? ""
+        };
 
-        if (appInsightsConfig != null)
-        {
-            builder.ConfigureOpenTelemetry(appInsightsConfig);
-        }
-        else
-        {
-            Console.WriteLine("App Insights Not Configured!");
-        }
+        builder.ConfigureOpenTelemetry(appInsightsConfig);
 
         builder.Services.AddControllers();
         builder.Services.AddEndpointsApiExplorer();


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this PR closes an issue, add '<[AB#213700](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/213700)>' somewhere in the PR summary. As a minimum, please *always* link to the relevant work items e.g. [AB#213700](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/213700) (work item number in Azure DevOps). Follow the format below carefully, guidance found here: https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops. Note: The Title pattern should be `{work item number}: {title}` -->

# Pull Request Details

## What this PR does / why we need it:
This PR contains the changes in dotnet backend template to use the same app insights config names as in nodejs and to use the connection string from shared label in Azure app configuration.
[AB#275171](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/275171)

## Special notes for your reviewer
*Any specific actions or notes on review?*

## Testing
Tested a sample scaffolded app with these code changes on SND3 cluster.

## Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [ ] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [ ] This PR contains documentation
- [ ] This PR contains tests

## How does this PR make you feel:
![gif]([https://giphy.com/)