### PR TITLE
405164: Remove Service Connection field, make ADO org readonly

### DIFF
--- a/templates/parameters/ci-cd.yaml
+++ b/templates/parameters/ci-cd.yaml
@@ -10,14 +10,10 @@ properties:
     title: Azure DevOps Organization
     type: string
     default: defragovuk
+    ui:readonly: true
   ado_project:
     title: Azure DevOps Project
     type: string
-  service_connection_name:
-    title: Service Connection Name
-    type: string
-    description: Name of the Service Connection used to connect to GitHub.
-    default: DEFRA
   pipeline_folder:
     title: Pipeline Folder
     type: string

--- a/templates/steps/ado-get-service-connection.yaml
+++ b/templates/steps/ado-get-service-connection.yaml
@@ -5,4 +5,4 @@ if: ${{ steps.configureAdoProject.output.code == 200 }}
 input:
   organization: ${{ parameters.ado_organization }}
   project: ${{ parameters.ado_project }}
-  serviceConnectionName: ${{ parameters.service_connection_name }}
+  serviceConnectionName: DEFRA


### PR DESCRIPTION
# Pull Request Details

## What this PR does / why we need it:
Removes the ADO Service Connection field from scaffolder forms, and makes the ADO Organization field readonly. [AB#405164](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/405164)

## Special notes for your reviewer


## Testing
*Any relevant testing information and pipeline runs.*

## Checklist (please delete before completing or setting auto-complete)
- [x] Story Work items associated (not Tasks)
- [x] Successful testing run(s) link provided
- [x] Title pattern should be `{work item number}: {title}`
- [x] Description covers all the changes in the PR
- [x] This PR contains documentation
- [x] This PR contains tests

## How does this PR make you feel:
![gif]([https://giphy.com/)