### PR TITLE
391772: Restrict owner selection to delivery projects you are a member of.

### DIFF
--- a/templates/adp-backend-template-dotnet/template.dev.yaml
+++ b/templates/adp-backend-template-dotnet/template.dev.yaml
@@ -62,11 +62,7 @@ spec:
           title: Owner
           type: string
           description: Select the team who will own this component
-          ui:field: OwnerPicker
-          ui:options:
-            catalogFilter:
-              - kind: Group
-                spec.type: delivery-project
+          ui:field: DeliveryProjectPicker
 
         app_infra_service_bus_check:
           title: Do you need an Azure Service Bus Queue or Topic?

--- a/templates/adp-backend-template-dotnet/template.yaml
+++ b/templates/adp-backend-template-dotnet/template.yaml
@@ -62,11 +62,7 @@ spec:
           title: Owner
           type: string
           description: Select the team who will own this component
-          ui:field: OwnerPicker
-          ui:options:
-            catalogFilter:
-              - kind: Group
-                spec.type: delivery-project
+          ui:field: DeliveryProjectPicker
 
         app_infra_service_bus_check:
           title: Do you need an Azure Service Bus Queue or Topic?

--- a/templates/adp-backend-template-node/template.dev.yaml
+++ b/templates/adp-backend-template-node/template.dev.yaml
@@ -64,11 +64,7 @@ spec:
           title: Owner
           type: string
           description: Select the team who will own this component
-          ui:field: OwnerPicker
-          ui:options:
-            catalogFilter:
-              - kind: Group
-                spec.type: delivery-project
+          ui:field: DeliveryProjectPicker
 
         app_infra_service_bus_check:
           title: Do you need an Azure Service Bus Queue or Topic?

--- a/templates/adp-backend-template-node/template.yaml
+++ b/templates/adp-backend-template-node/template.yaml
@@ -64,11 +64,7 @@ spec:
           title: Owner
           type: string
           description: Select the team who will own this component
-          ui:field: OwnerPicker
-          ui:options:
-            catalogFilter:
-              - kind: Group
-                spec.type: delivery-project
+          ui:field: DeliveryProjectPicker
 
         app_infra_service_bus_check:
           title: Do you need an Azure Service Bus Queue or Topic?

--- a/templates/adp-empty-project-template/template.dev.yaml
+++ b/templates/adp-empty-project-template/template.dev.yaml
@@ -56,11 +56,7 @@ spec:
           title: Owner
           type: string
           description: Select the team who will own this component
-          ui:field: OwnerPicker
-          ui:options:
-            catalogFilter:
-              - kind: Group
-                spec.type: delivery-project
+          ui:field: DeliveryProjectPicker
 
         system:
           title: System

--- a/templates/adp-empty-project-template/template.yaml
+++ b/templates/adp-empty-project-template/template.yaml
@@ -56,11 +56,7 @@ spec:
           title: Owner
           type: string
           description: Select the team who will own this component
-          ui:field: OwnerPicker
-          ui:options:
-            catalogFilter:
-              - kind: Group
-                spec.type: delivery-project
+          ui:field: DeliveryProjectPicker
 
         system:
           title: System

--- a/templates/adp-frontend-template-node/template.dev.yaml
+++ b/templates/adp-frontend-template-node/template.dev.yaml
@@ -76,11 +76,7 @@ spec:
           title: Owner
           type: string
           description: Select the team who will own this component
-          ui:field: OwnerPicker
-          ui:options:
-            catalogFilter:
-              - kind: Group
-                spec.type: delivery-project
+          ui:field: DeliveryProjectPicker
 
         app_infra_service_bus_check:
           title: Do you need an Azure Service Bus Queue or Topic?

--- a/templates/adp-frontend-template-node/template.yaml
+++ b/templates/adp-frontend-template-node/template.yaml
@@ -76,11 +76,7 @@ spec:
           title: Owner
           type: string
           description: Select the team who will own this component
-          ui:field: OwnerPicker
-          ui:options:
-            catalogFilter:
-              - kind: Group
-                spec.type: delivery-project
+          ui:field: DeliveryProjectPicker
 
         app_infra_service_bus_check:
           title: Do you need an Azure Service Bus Queue or Topic?

--- a/templates/adp-helm-only-template/template.dev.yaml
+++ b/templates/adp-helm-only-template/template.dev.yaml
@@ -58,11 +58,7 @@ spec:
           title: Owner
           type: string
           description: Select the team who will own this component
-          ui:field: OwnerPicker
-          ui:options:
-            catalogFilter:
-              - kind: Group
-                spec.type: delivery-project
+          ui:field: DeliveryProjectPicker
 
         endpoint:
           title: Endpoint

--- a/templates/adp-helm-only-template/template.yaml
+++ b/templates/adp-helm-only-template/template.yaml
@@ -58,11 +58,7 @@ spec:
           title: Owner
           type: string
           description: Select the team who will own this component
-          ui:field: OwnerPicker
-          ui:options:
-            catalogFilter:
-              - kind: Group
-                spec.type: delivery-project
+          ui:field: DeliveryProjectPicker
 
         endpoint:
           title: Endpoint


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this PR closes an issue, add '<[AB#213700](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/213700)>' somewhere in the PR summary. As a minimum, please *always* link to the relevant work items e.g. [AB#213700](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/213700) (work item number in Azure DevOps). Follow the format below carefully, guidance found here: https://learn.microsoft.com/en-us/azure/devops/boards/github/link-to-from-github?view=azure-devops. Note: The Title pattern should be `{work item number}: {title}` -->

# Pull Request Details

## What this PR does / why we need it:
[AB#391772](https://dev.azure.com/defragovuk/93c65135-d16b-49d6-a191-4a5313532779/_workitems/edit/391772) Makes use of the new DeliveryProjectPicker field to only allow projects that the current user is a member of as options.

## Special notes for your reviewer
*Any specific actions or notes on review?*

## Testing
*Any relevant testing information and pipeline runs.*

## How does this PR make you feel:
![gif]([https://giphy.com/)